### PR TITLE
Add server side session support

### DIFF
--- a/hackspace_storage/__init__.py
+++ b/hackspace_storage/__init__.py
@@ -44,12 +44,12 @@ def create_app(test_config=None):
 
 
 def register_extensions(app: Flask):
-    from .extensions import db, migrate
-    from . import login
+    from .database import db, migrate
+    from .login import login_manager
     from . import booking_rules
     db.init_app(app)
     migrate.init_app(app)
-    login.init_app(app)
+    login_manager.init_app(app)
     booking_rules.init_app(app)
 
 

--- a/hackspace_storage/__init__.py
+++ b/hackspace_storage/__init__.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import logging
 import os
 import sys
@@ -15,7 +16,8 @@ def create_app(test_config=None):
         SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres:postgres@localhost:5432/hackspace_storage",
         LOGIN_START_SECRET="dev",
         PORTAL_URL="https://example.com",
-        SENDER_EMAIL="Example <example@example.com>"
+        SENDER_EMAIL="Example <example@example.com>",
+        IDLE_SESSION_LIFETIME=timedelta(minutes=20).total_seconds(),
     )
 
     if test_config is None:

--- a/hackspace_storage/booking_rules.py
+++ b/hackspace_storage/booking_rules.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 from flask import Flask
 
-from hackspace_storage.extensions import db
+from hackspace_storage.database import db
 from hackspace_storage.models import User, Slot, Booking
 from hackspace_storage.token import generate_token
 

--- a/hackspace_storage/database.py
+++ b/hackspace_storage/database.py
@@ -2,10 +2,13 @@ from datetime import datetime, timezone
 import functools
 from zoneinfo import ZoneInfo
 from flask import current_app
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import types
 from sqlalchemy.orm import Mapped, mapped_column
 
-from hackspace_storage.extensions import db
+db = SQLAlchemy()
+migrate = Migrate(db=db)
 
 Model = db.Model
 
@@ -55,7 +58,6 @@ class LocalDateTime(types.TypeDecorator):
         if value is not None:
             zone = local_timezone()
             return value.replace(tzinfo=timezone.utc).astimezone(zone)
-
 
 
 class SpaceSeparatedSet(types.TypeDecorator):

--- a/hackspace_storage/extensions.py
+++ b/hackspace_storage/extensions.py
@@ -1,5 +1,0 @@
-from flask_sqlalchemy import SQLAlchemy
-from flask_migrate import Migrate
-
-db = SQLAlchemy()
-migrate = Migrate(db=db)

--- a/hackspace_storage/login.py
+++ b/hackspace_storage/login.py
@@ -8,73 +8,54 @@ from typing import Any
 import uuid
 import jwt
 from flask import Flask, Request, Response, abort, after_this_request, current_app, g, request, session
+from flask_sqlalchemy import SQLAlchemy
 
-from hackspace_storage.extensions import db
-from hackspace_storage.models import User, Session
-from hackspace_storage.token import generate_token, token_to_id
-
-
-def create_session(user: User, sid: str|None):
-    now = datetime.now(timezone.utc)
-    idle_session_lifetime = timedelta(seconds=current_app.config["IDLE_SESSION_LIFETIME"])
-    expiry = now + idle_session_lifetime
-    secret = generate_token()
-    stmt = insert(Session).values(
-        id=uuid.uuid4(),
-        secret=token_to_id(secret),
-        external_id=sid,
-        user_id=user.id,
-        created=now,
-        expiry=expiry
-    ).on_conflict_do_update(
-        index_elements=[Session.external_id],
-        set_=dict(
-            secret=token_to_id(secret),
-            user_id=user.id,
-            created=now,
-            expiry=expiry,
-        )
-    ).returning(Session)
-
-    orm_stmt = sa.select(Session).from_statement(stmt).execution_options(populate_existing=True)
-    session: Session = db.session.execute(orm_stmt).scalar_one()
-    db.session.commit()
-
-    g.session = session
-    g.user = session.user
-
-    @after_this_request
-    def update_session(response: Response):
-        session_value = f"{session.id.hex}:{secret}"
-        response.set_cookie(
-            "id",
-            session_value,
-            max_age=idle_session_lifetime,
-            secure=current_app.config["SESSION_COOKIE_SECURE"],
-            httponly=current_app.config["SESSION_COOKIE_HTTPONLY"]
-        )
+from hackspace_storage.models import User, Login
 
 
+def _make_timedelta(value: timedelta | int) -> timedelta:
+    if isinstance(value, timedelta):
+        return value
 
-def init_app(app: Flask):
-    @app.before_request
-    def login_from_request() -> None:
-        login_token = request.args.get('login_token')
-        if login_token is None:
-            return None
+    return timedelta(seconds=value)
 
-        start_secret = current_app.config["LOGIN_START_SECRET"]
+
+class LoginManager:
+    def __init__(self, db: SQLAlchemy):
+        self.db = db
+
+    def init_app(self, app: Flask):
+        self.idle_timeout = _make_timedelta(current_app.config.get("LOGIN_IDLE_TIMEOUT", 60*10))
+        self.absolute_timeout = _make_timedelta(current_app.config.get("LOGIN_ABSOLUTE_TIMEOUT", 60*60))
+        self.cookie_name = current_app.config.get("LOGIN_COOKIE_NAME", "id")
+        self.cookie_secure = current_app.config.get("LOGIN_COOKIE_SECURE", False)
+        self.start_secret = current_app.config["LOGIN_START_SECRET"]
+
+        @app.before_request
+        def do_login():
+            login_token = request.args.get('login_token')
+            if login_token is not None:
+                self.login_from_token(login_token)
+
+            if 'user' not in g:
+                self.login_from_cookie()
+
+    def login_from_token(self, login_token: str):
         try:
-            decoded_token = jwt.decode(
+            decoded_token: dict[str, Any] = jwt.decode(
                 login_token,
-                start_secret,
+                self.start_secret,
                 algorithms="HS256",
                 options=dict(require=["exp"])
             )
         except jwt.PyJWTError as ex:
             current_app.logger.warning(f"Error decoding login token {ex}")
             return None
+        
+        user = self.create_user_from_id_token(decoded_token)
+        self.create_login(user, decoded_token.get("sid"))
 
+    def create_user_from_id_token(self, decoded_token: dict[str, Any]) -> User:
         sub = decoded_token["sub"]
         email = decoded_token["email"]
         name = decoded_token["name"]
@@ -96,35 +77,74 @@ def init_app(app: Flask):
         user = db.session.execute(orm_stmt).scalar_one()
         db.session.commit()
 
-        create_session(user, decoded_token.get("sid"))
+        return user
 
-        return None
-
-    @app.before_request
-    def login_from_session() -> None:
-        if 'session' in g:
-            return
-
-        session_value = request.cookies.get("id", "").split(":")
-        if len(session_value) != 2:
-            return
-        session_id, secret = session_value
-
-        session = db.session.get(Session, session_id)
-        if not session:
-            return
-        
-        if not secrets.compare_digest(session.secret, token_to_id(secret)):
-            return
-        
+    def create_login(self, user: User, sid: str|None):
         now = datetime.now(timezone.utc)
-        if now > session.expiry:
+        expiry = now + self.idle_timeout
+        secret = secrets.token_urlsafe()
+        stmt = insert(Login).values(
+            id=uuid.uuid4(),
+            secret=secret,
+            external_id=sid,
+            user_id=user.id,
+            created=now,
+            expiry=expiry
+        ).on_conflict_do_update(
+            index_elements=[Login.external_id],
+            set_=dict(
+                secret=secret,
+                user_id=user.id,
+                created=now,
+                expiry=expiry,
+            )
+        ).returning(Login)
+
+        orm_stmt = sa.select(Login).from_statement(stmt).execution_options(populate_existing=True)
+        login: Login = db.session.execute(orm_stmt).scalar_one()
+        db.session.commit()
+
+        g.user = user
+        g.login = login
+
+        @after_this_request
+        def update_session(response: Response):
+            session_value = f"{login.id.hex}:{secret}"
+            response.set_cookie(
+                self.cookie_name,
+                session_value,
+                secure=self.cookie_secure,
+                httponly=True
+            )
+
+    def login_from_cookie(self):
+        now = datetime.now(timezone.utc)
+
+        login_cookie = request.cookies.get(self.cookie_name)
+        if login_cookie is None:
             return
         
-        g.session = session
-        g.user = session.user
+        login_cookie = login_cookie.split(":")
+        if len(login_cookie) != 2:
+            return
+        
+        login_id, secret = login_cookie
+        login = db.session.get(Login, login_id)
+        if login is None:
+            return
+        
+        if now > login.expiry:
+            db.session.delete(login)
+            db.session.commit()
+            return
+        
+        if not secrets.compare_digest(secret, login.secret):
+            return
 
-        session.expiry = now + current_app.permanent_session_lifetime
+        g.user = login.user
+        g.login = login
+
+        login.expiry = now + self.idle_timeout
         db.session.commit()
 
 

--- a/hackspace_storage/main/views.py
+++ b/hackspace_storage/main/views.py
@@ -11,8 +11,8 @@ from hackspace_storage.booking_rules import BookingError, try_make_booking, exte
 from hackspace_storage.mailer import send_email
 
 from .forms import DeleteConfirmForm
-from hackspace_storage.extensions import db
-from hackspace_storage.login import login_required
+from hackspace_storage.database import db
+from hackspace_storage.login import login_required, login_manager
 from hackspace_storage.models import Area, Slot, User, Booking
 
 bp = Blueprint("main", __name__, url_prefix="/")
@@ -149,3 +149,15 @@ def extend(booking_id: int):
     except BookingError as ex:
         flash(ex.reason, 'error')
     return redirect(url_for('main.index'))
+
+
+@bp.route("/backchannel-logout", methods=["POST"])
+def backchannel_logout():
+    logout_token = request.form.get("logout_token")
+    if logout_token is None:
+        abort(400)
+
+    if not login_manager.process_logout_token(logout_token):
+        abort (400)
+
+    return ""

--- a/hackspace_storage/models.py
+++ b/hackspace_storage/models.py
@@ -16,7 +16,7 @@ class User(PkModel):
     name: Mapped[str]
 
     bookings: Mapped[list["Booking"]] = relationship(back_populates="user")
-    sessions: Mapped[list["Session"]] = relationship(back_populates="user")
+    logins: Mapped[list["Login"]] = relationship(back_populates="user")
 
     def bookings_per_category(self) -> defaultdict["Category", int]:
         counts = defaultdict(int)
@@ -24,8 +24,8 @@ class User(PkModel):
             counts[booking.slot.area.category] += 1
         return counts
     
-
-class Session(Model):
+# Calling this a Login instead of Session to avoid confusion with Flask's own session API
+class Login(Model):
     id: Mapped[UUID]
     external_id: Mapped[Optional[str]] = mapped_column(unique=True, index=True) # Obtained from the sid claim in the login token
     # We don't just rely on the id as UUID generation isn't guaranteed to use a CSPRNG

--- a/hackspace_storage/models.py
+++ b/hackspace_storage/models.py
@@ -8,7 +8,7 @@ from sqlalchemy.sql import func, expression
 from uuid import UUID
 
 from hackspace_storage.database import PkModel, Model, UTCDateTime
-from hackspace_storage.extensions import db
+from hackspace_storage.database import db
 
 class User(PkModel):
     sub: Mapped[str] = mapped_column(unique=True, index=True) # ID will be obtained from the subject claim in the login token
@@ -26,7 +26,7 @@ class User(PkModel):
     
 # Calling this a Login instead of Session to avoid confusion with Flask's own session API
 class Login(Model):
-    id: Mapped[UUID]
+    id: Mapped[UUID] = mapped_column(primary_key=True)
     external_id: Mapped[Optional[str]] = mapped_column(unique=True, index=True) # Obtained from the sid claim in the login token
     # We don't just rely on the id as UUID generation isn't guaranteed to use a CSPRNG
     secret: Mapped[str]
@@ -34,7 +34,7 @@ class Login(Model):
     created: Mapped[datetime.datetime] = mapped_column(UTCDateTime())
     expiry: Mapped[datetime.datetime] = mapped_column(UTCDateTime())
 
-    user: Mapped["User"] = relationship(back_populates="sessions")
+    user: Mapped["User"] = relationship(back_populates="logins")
 
 class Category(PkModel):
     name: Mapped[str]

--- a/hackspace_storage/nightly.py
+++ b/hackspace_storage/nightly.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 from flask import Blueprint
 import sqlalchemy as sa
 
-from hackspace_storage.extensions import db
+from hackspace_storage.database import db
 from hackspace_storage.models import Area, Category, Slot, Booking, User
 
 bp = Blueprint('nightly', __name__, cli_group=None)

--- a/hackspace_storage/token.py
+++ b/hackspace_storage/token.py
@@ -1,12 +1,19 @@
 import base64
 import hashlib
 import secrets
+from typing import overload
 
 TOKEN_BYTES = 32
 HASH_ALGORITHM = "sha256"
 
 def generate_token() -> str:
     return secrets.token_urlsafe(TOKEN_BYTES)
+
+@overload
+def token_to_id(token: str) -> str: ...
+
+@overload
+def token_to_id(token: None) -> None: ...
 
 def token_to_id(token: str | None) -> str | None:
     if token is None:


### PR DESCRIPTION
These are called Logins instead of Sessions to avoid confusion with Flask's built in session support. This implementation allows:

- Login idle expiry.
- Login absolute expiry (expiry regardless of how much activity there is).
- External session IDs (`sid`) when logging in.
- Backchannel logout using those session IDs.
- Session rotation if logging in with the same `sid`.